### PR TITLE
Added support for pydicom_PIL.py to run from the command line

### DIFF
--- a/viewers/pydicom_PIL.py
+++ b/viewers/pydicom_PIL.py
@@ -8,6 +8,9 @@ Usage:
 >>> ds = pydicom.read_file("filename")
 >>> show_PIL(ds)
 
+Or from the command line:
+python pydicom_PIL.py <<filename>>
+
 Requires Numpy:
     http://numpy.scipy.org/
 
@@ -110,3 +113,10 @@ def show_PIL(dataset):
     """Display an image using the Python Imaging Library (PIL)"""
     im = get_PIL_image(dataset)
     im.show()
+
+
+if __name__ == '__main__':
+    import pydicom
+    import sys
+    ds = pydicom.read_file(sys.argv[1])
+    show_PIL(ds)

--- a/viewers/pydicom_PIL.py
+++ b/viewers/pydicom_PIL.py
@@ -117,6 +117,29 @@ def show_PIL(dataset):
 
 if __name__ == '__main__':
     import pydicom
+    import argparse
     import sys
-    ds = pydicom.read_file(sys.argv[1])
-    show_PIL(ds)
+    import os.path
+
+    # Set up argparser to parse the command-line arguments
+    class DefaultParser(argparse.ArgumentParser):
+        """Custom argparse class."""
+
+        def error(self, message):
+            """Default error handler."""
+            sys.stderr.write('error: %s\n' % message)
+            self.print_help()
+            sys.exit(2)
+
+    parser = DefaultParser(
+        description="View DICOM images using the Python Image Library.")
+    parser.add_argument(
+        "filename", help="Filename of DICOM image")
+
+    args = parser.parse_args()
+
+    if os.path.isfile(args.filename):
+        ds = pydicom.read_file(args.filename)
+        show_PIL(ds)
+    else:
+        parser.error('%s is not a valid file.' % args.filename)


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/contrib-pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->

#### What contibution are you adding? How do we use it?
<!--
If additional dependencies are required for your example, please
include these. Also take into consideration data.
-->
The pydicom_PIL.py script can now accept command line arguments to display images. Prior to this PR, it would be necessary to import the module from another script.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->

 - [ ] I have added a single script or subfolder to a topic folder
 - [x] I have added some form of documentation and my contact with the contribution
 - [ ] I have added a link to the contribution in the topic folder's `README.md`
